### PR TITLE
http

### DIFF
--- a/src/http.js
+++ b/src/http.js
@@ -155,6 +155,11 @@ class HttpClient {
     var headers = options.headers;
     var req;
 
+    // check if there is a cookie jar in options
+    if (this.options.jar) {
+      options.jar = this.options.jar;
+    }
+
     //typically clint.js would do addOptions() if security is set in order to get all security options added to options{}. But client.js
     //addOptions() code runs after this code is trying to contact server to load remote WSDL, hence we have NTLM authentication
     //object passed in as option to createClient() call for now. Revisit.


### PR DESCRIPTION
include the option to use cookies

### Description

Add the capacity to make statefull requests using cookies.

### Checklist

- [ X ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
