### PR TITLE
upgraded lodash version to 4.17.21 from 4.17.20. This will guard stro…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3889,9 +3889,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "http://fpnex001.na.atxglobal.com:8081/nexus/repository/npm-all/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "compress": "^0.99.0",
     "debug": "^4.1.1",
     "httpntlm-maa": "^2.0.6",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "node-rsa": "^1.1.1",
     "request": "^2.72.0",
     "sax": "^1.2",


### PR DESCRIPTION
upgraded lodash version to 4.17.21 from 4.17.20. This will guard strong-soap from security vulnerabilities coming in through this depemdency. Following are some security vulnerabilities fixed in lodash 4.17.21. more info at https://snyk.io/test/npm/lodash/4.17.21

issues reported: https://github.com/lodash/lodash/issues/5083

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
