### PR TITLE
Typo in example server code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,8 +642,8 @@ Creates a new SOAP server that listens on *path* and provides *services*.
               },
 
               // You can also inspect the original `req`
-              reallyDeatailedFunction: function(args, cb, headers, req) {
-                  console.log('SOAP `reallyDeatailedFunction` request from ' + req.connection.remoteAddress);
+              reallyDetailedFunction: function(args, cb, headers, req) {
+                  console.log('SOAP `reallyDetailedFunction` request from ' + req.connection.remoteAddress);
                   return {
                       name: headers.Token
                   };


### PR DESCRIPTION
### Description
Just found a typo. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
