### PR TITLE
ci: restrict branch builds to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ arch:
   - ard64
   - ppc64le
   - s390x
+branches:
+  only:
+    - master
 language: node_js
 env:
   NODE_OPTIONS: --max-old-space-size=4096


### PR DESCRIPTION
This is to prevent Travis from running builds twice on pull requests and reduce the number of builds executed within the repo.

This also aligns with the GitHub Actions workflow.

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
