### PR TITLE
ci: restrict GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -10,6 +10,8 @@ on:
   schedule:
     - cron: '0 2 * * 1' # At 02:00 on Monday
 
+permissions: {}
+
 jobs:
   test:
     name: Test
@@ -88,6 +90,9 @@ jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest
+    permissions:
+      # See: https://github.com/github/codeql-action/blob/008b2cc71c4cf3401f45919d8eede44a65b4a322/README.md#usage
+      security-events: write
     steps:
     - uses: actions/checkout@v2
     - name: Initialize CodeQL


### PR DESCRIPTION
see: https://github.com/loopbackio/loopback-next/pull/7867

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- New tests added or existing tests modified to cover all changes
- Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
