### PR TITLE
chore: bump xml-crypto 2.1.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "selectn": "^1.0.20",
         "strong-globalize": "^6.0.5",
         "uuid": "^8.3.1",
-        "xml-crypto": "^2.1.1",
+        "xml-crypto": "^2.1.3",
         "xmlbuilder": "^10.1.1"
       },
       "devDependencies": {
@@ -2418,6 +2418,14 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.4.tgz",
+      "integrity": "sha512-wdxC79cvO7PjSM34jATd/RYZuYWQ8y/R7MidZl1NYYlbpFn1+spfjkiR3ZsJfcaTs2IyslBN7VwBBJwrYKM+zw==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/accept-language": {
       "version": "3.0.18",
@@ -9921,11 +9929,11 @@
       "dev": true
     },
     "node_modules/xml-crypto": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.1.tgz",
-      "integrity": "sha512-M+m4+HIJa83lu/CnspQjA7ap8gmanNDxxRjSisU8mPD4bqhxbo5N2bdpvG2WgVYOrPpOIOq55iY8Cz8Ai40IeQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.3.tgz",
+      "integrity": "sha512-MpXZwnn9JK0mNPZ5mnFIbNnQa+8lMGK4NtnX2FlJMfMWR60sJdFO9X72yO6ji068pxixzk53O7x0/iSKh6IhyQ==",
       "dependencies": {
-        "xmldom": "0.5.0",
+        "@xmldom/xmldom": "^0.7.0",
         "xpath": "0.0.32"
       },
       "engines": {
@@ -9938,14 +9946,6 @@
       "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==",
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/xpath": {
@@ -11822,6 +11822,11 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "@xmldom/xmldom": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.4.tgz",
+      "integrity": "sha512-wdxC79cvO7PjSM34jATd/RYZuYWQ8y/R7MidZl1NYYlbpFn1+spfjkiR3ZsJfcaTs2IyslBN7VwBBJwrYKM+zw=="
     },
     "accept-language": {
       "version": "3.0.18",
@@ -17701,11 +17706,11 @@
       "dev": true
     },
     "xml-crypto": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.1.tgz",
-      "integrity": "sha512-M+m4+HIJa83lu/CnspQjA7ap8gmanNDxxRjSisU8mPD4bqhxbo5N2bdpvG2WgVYOrPpOIOq55iY8Cz8Ai40IeQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.3.tgz",
+      "integrity": "sha512-MpXZwnn9JK0mNPZ5mnFIbNnQa+8lMGK4NtnX2FlJMfMWR60sJdFO9X72yO6ji068pxixzk53O7x0/iSKh6IhyQ==",
       "requires": {
-        "xmldom": "0.5.0",
+        "@xmldom/xmldom": "^0.7.0",
         "xpath": "0.0.32"
       }
     },
@@ -17713,11 +17718,6 @@
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-10.1.1.tgz",
       "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="
-    },
-    "xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
     },
     "xpath": {
       "version": "0.0.32",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "selectn": "^1.0.20",
     "strong-globalize": "^6.0.5",
     "uuid": "^8.3.1",
-    "xml-crypto": "^2.1.1",
+    "xml-crypto": "^2.1.3",
     "xmlbuilder": "^10.1.1"
   },
   "repository": {


### PR DESCRIPTION
Signed-off-by: push1st1k <alex060t@gmail.com>

### Description
`xml-crypto` library is using `xmldom`, which has vulnerability according to https://www.npmjs.com/advisories/1769. Updating it to the 2.1.3 should solve that issue as a version with a fix (^0.7.0) is using there.

### Checklist
<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
