### PR TITLE
fix: fixed installing the library from npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "strong-soap",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "strong-soap",
-      "version": "3.2.1",
+      "version": "3.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -44,6 +44,7 @@
         "jshint": "^2.12.0",
         "mocha": "^8.2.0",
         "nyc": "^15.1.0",
+        "pinst": "^2.1.6",
         "readable-stream": "^3.6.0",
         "semver": "^7.3.2",
         "should": "^13.2.1",
@@ -7657,6 +7658,41 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pinst": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
+      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
+      "dev": true,
+      "dependencies": {
+        "fromentries": "^1.3.2"
+      },
+      "bin": {
+        "pinst": "bin.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/pinst/node_modules/fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -15860,6 +15896,23 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+    },
+    "pinst": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/pinst/-/pinst-2.1.6.tgz",
+      "integrity": "sha512-B4dYmf6nEXg1NpDSB+orYWvKa5Kfmz5KzWC29U59dpVM4S/+xp0ak/JMEsw04UQTNNKps7klu0BUalr343Gt9g==",
+      "dev": true,
+      "requires": {
+        "fromentries": "^1.3.2"
+      },
+      "dependencies": {
+        "fromentries": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+          "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+          "dev": true
+        }
+      }
     },
     "pkg-dir": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "scripts": {
     "postinstall": "husky install",
     "build": "babel src --source-maps --out-dir=lib",
-    "prepublishOnly": "npm run build",
+    "prepublishOnly": "pinst --disable && npm run build",
+    "postpublish": "pinst --enable",
     "toc": "doctoc Readme.md --github --maxlevel 3",
     "_pretest": "jshint index.js lib test",
     "test": "nyc --reporter=lcov mocha --exit --timeout 60000 test/*-test.js test/security/*.js"
@@ -60,6 +61,7 @@
     "jshint": "^2.12.0",
     "mocha": "^8.2.0",
     "nyc": "^15.1.0",
+    "pinst": "^2.1.6",
     "readable-stream": "^3.6.0",
     "semver": "^7.3.2",
     "should": "^13.2.1",


### PR DESCRIPTION
Signed-off-by: push1st1k <alex060t@gmail.com>

### Description
After upgrade to the version 3.3.0 it's not possible to install the library via NPM. The error message is
```
npm ERR! command failed
npm ERR! command sh -c husky install
npm ERR! .git can't be found (see https://git.io/Jc3F9)
```
The fix is described [here](https://typicode.github.io/husky/#/?id=install-1).

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
