### PR TITLE
Stop listing Babel as a production dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "node": ">=8.11.1"
   },
   "dependencies": {
-    "@babel/cli": "^7.14.8",
-    "@babel/core": "^7.15.0",
-    "@babel/preset-env": "^7.15.0",
     "compress": "^0.99.0",
     "debug": "^4.1.1",
     "httpntlm-maa": "^2.0.6",
@@ -44,6 +41,9 @@
   ],
   "license": "MIT",
   "devDependencies": {
+    "@babel/cli": "^7.14.8",
+    "@babel/core": "^7.15.0",
+    "@babel/preset-env": "^7.15.0",
     "@commitlint/cli": "^13.1.0",
     "@commitlint/config-conventional": "^13.1.0",
     "async": "^3.2.0",


### PR DESCRIPTION
### Description

The Babel packages `@babel/cli`, `@babel/core` and `@babel/preset-env` are almost always only used at development time, not at run time. Listing them as production dependencies results in a large number of unnecessary packages being installed by downstream consumers. Relegating these to development dependencies *greatly* improves matters for a consumer of `strong-soap`:

* From 301 direct and indirect dependencies down to 116
* From 29.5MB of `node_modules` on disk down to 13.9MB

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
