### PR TITLE
fix: return a 415 if the call has no Content-Type in the headers

### DIFF
--- a/test/server-test.js
+++ b/test/server-test.js
@@ -202,14 +202,33 @@ describe('SOAP Server', function() {
         body : '<soapenv:Envelope' +
                     ' xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"' +
                     ' xmlns:soap="http://service.applicationsnet.com/soap/">' +
-                '  <soapenv:Header/>' +
                 '  <soapenv:Body>' +
+      '  <soapenv:Header/>' +
                 '</soapenv:Envelope>',
         headers: {'Content-Type': 'text/xml'}
       }, function(err, res, body) {
         assert.ok(!err);
         assert.equal(res.statusCode, 500);
         assert.ok(body.length);
+        done();
+      }
+    );
+  });
+
+  it('should 415 on missing Content-type header', function(done) {
+    request.post({
+        url: test.baseUrl + '/stockquote?wsdl',
+        body : '<soapenv:Envelope' +
+                    ' xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"' +
+                    ' xmlns:soap="http://service.applicationsnet.com/soap/">' +
+                '  <soapenv:Header/>' +
+                '  <soapenv:Body>' +
+                '</soapenv:Envelope>',
+        headers: {}
+      }, function(err, res, body) {
+        assert.ok(!err);
+        assert.equal(res.statusCode, 415);
+        assert.equal(body, 'The Content-Type is expected in the headers');
         done();
       }
     );
@@ -360,7 +379,7 @@ describe('SOAP Server', function() {
         assert.equal(0, parseFloat(result.price));
         done();
       }, {
-        soapHeaders: { 
+        soapHeaders: {
           SomeToken: 123.45
         }
       });


### PR DESCRIPTION
Signed-off-by: François Cabrol <fcabrol@spectre-music.com>

### Description
If I do a curl to the strong-api route without headers neither body an issue is thrown and is not caught anywhere Invalid value "undefined" for header "Content-Type"

We decided here #375 that the api should return a 415 error.

#### Related issues

- connect to #375

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
