### PR TITLE
chore: use node.js 16 for commit lint GH action

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -82,10 +82,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Use Node.js 14
+      - name: Use Node.js 16
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
       - name: Bootstrap project
         run: npm ci --ignore-scripts
       - name: Verify commit linting


### PR DESCRIPTION
Signed-off-by: dhmlau <dhmlau@ca.ibm.com>

There seems to be an issue to use Node.js 14 when running commit lint GH action. Updating it to use Node.js 16 fixes the issue. 