### PR TITLE
feat: support additional parameter for optional date timezone

### DIFF
--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -886,16 +886,17 @@ function parseValue(text, descriptor) {
 /**
  * 
  * @param {string | Date} date 
- * @param {Object} options 
- * @param {Object} options.date
- * @param {Object} options.date.timezone
- * @param {boolean} options.date.timezone.enabled
+ * @param {Object} [options] 
+ * @param {Object} [options.date]
+ * @param {Object} [options.date.timezone]
+ * @param {boolean} [options.date.timezone.enabled]
  * @returns 
  */
 function toXmlDate(date, options) {
   const isoStr = new Date(date).toISOString();
   const formattedDate = isoStr.split('T')[0];
-  if (!options.date.timezone.enabled) {
+  const withTimezone = (options && options.date && options.date.timezone) && typeof options.date.timezone.enabled === 'boolean' ? options.date.timezone.enabled : true;
+  if (!withTimezone) {
     return formattedDate;
   }
   return formattedDate + 'Z';

--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -42,7 +42,7 @@ class XMLHandler {
     this.options.xsiTypeKey = this.options.xsiTypeKey || '$xsiType';
     this.options.date = this.options.date || {};
     this.options.date.timezone = this.options.date.timezone || {};
-    this.options.date.timezone.enabled = typeof this.options.date.timezone.enabled === 'boolean' ? this.options.date.timezone.enabled : false;
+    this.options.date.timezone.enabled = typeof this.options.date.timezone.enabled === 'boolean' ? this.options.date.timezone.enabled : true;
   }
 
   jsonToXml(node, nsContext, descriptor, val) {
@@ -893,7 +893,8 @@ function parseValue(text, descriptor) {
  * @returns 
  */
 function toXmlDate(date, options) {
-  const isoStr = new Date(date).toISOString();
+  date = new Date(date);
+  const isoStr = date.toISOString();
   const formattedDate = isoStr.split('T')[0];
   const withTimezone = (options && options.date && options.date.timezone) && typeof options.date.timezone.enabled === 'boolean' ? options.date.timezone.enabled : true;
   if (!withTimezone) {
@@ -903,12 +904,14 @@ function toXmlDate(date, options) {
 }
 
 function toXmlTime(date) {
-  const isoStr = new Date(date).toISOString();
+  date = new Date(date);
+  const isoStr = date.toISOString();
   return isoStr.split('T')[1];
 }
 
 function toXmlDateTime(date) {
-  return new Date(date).toISOString();
+  date = new Date(date);
+  return date.toISOString();
 }
 
 /**

--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -57,7 +57,7 @@ class XMLHandler {
     var name;
     let nameSpaceContextCreated = false;
     if (descriptor instanceof AttributeDescriptor) {
-      val = toXmlDateOrTime(descriptor, val, this.options);
+      val = toXmlDateOrTime(descriptor, val, this.options.date);
       name = descriptor.qname.name;
       if (descriptor.form === 'unqualified') {
         node.attribute(name, val);
@@ -131,7 +131,7 @@ class XMLHandler {
         && typeof val[this.options.xmlKey] !== "undefined") {
         val = val[this.options.xmlKey];
         element = node.element(elementName);
-        val = toXmlDateOrTime(descriptor, val, this.options);
+        val = toXmlDateOrTime(descriptor, val, this.options.date);
         element.raw(val);
       } else {
         // Enforce the type restrictions if configured for such
@@ -152,7 +152,7 @@ class XMLHandler {
             }
           }
         }
-        val = toXmlDateOrTime(descriptor, val, this.options);
+        val = toXmlDateOrTime(descriptor, val, this.options.date);
         element = isSimple ? node.element(elementName, val) : node.element(elementName);
       }
 
@@ -210,7 +210,7 @@ class XMLHandler {
       //val is not an object - simple or date types
       if (val != null && ( typeof val !== 'object' || val instanceof Date)) {
         // for adding a field value nsContext.popContext() shouldnt be called
-        val = toXmlDateOrTime(descriptor, val, this.options);
+        val = toXmlDateOrTime(descriptor, val, this.options.date);
         element.text(val);
         //add $attributes. Attribute can be an attribute defined in XSD or an xsi:type.
         //e.g of xsi:type <name xmlns=".." xmlns:xsi="..." xmlns:ns="..." xsi:type="ns:string">some name</name>
@@ -303,7 +303,7 @@ class XMLHandler {
   mapObject(node, nsContext, descriptor, val, attrs) {
     if (val == null) return node;
     if (typeof val !== 'object' || (val instanceof Date)) {
-      val = toXmlDateOrTime(descriptor, val, this.options);
+      val = toXmlDateOrTime(descriptor, val, this.options.date);
       node.text(val);
       return node;
     }
@@ -887,16 +887,15 @@ function parseValue(text, descriptor) {
  * 
  * @param {string | Date} date 
  * @param {Object} [options] 
- * @param {Object} [options.date]
- * @param {Object} [options.date.timezone]
- * @param {boolean} [options.date.timezone.enabled]
+ * @param {Object} [options.timezone]
+ * @param {boolean} [options.timezone.enabled]
  * @returns 
  */
 function toXmlDate(date, options) {
   date = new Date(date);
   const isoStr = date.toISOString();
   const formattedDate = isoStr.split('T')[0];
-  const withTimezone = (options && options.date && options.date.timezone) && typeof options.date.timezone.enabled === 'boolean' ? options.date.timezone.enabled : true;
+  const withTimezone = (options && options.timezone) && typeof options.timezone.enabled === 'boolean' ? options.timezone.enabled : true;
   if (!withTimezone) {
     return formattedDate;
   }
@@ -919,9 +918,8 @@ function toXmlDateTime(date) {
  * @param {object} descriptor 
  * @param {* | null} val 
  * @param {Object} options
- * @param {Object} options.date
- * @param {Object} options.date.timezone
- * @param {boolean} options.date.timezone.enabled
+ * @param {Object} options.timezone
+ * @param {boolean} options.timezone.enabled
  * @returns {string}
  */
 function toXmlDateOrTime(descriptor, val, options) {

--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -892,8 +892,7 @@ function parseValue(text, descriptor) {
  * @returns 
  */
 function toXmlDate(date, options) {
-  date = new Date(date);
-  const isoStr = date.toISOString();
+  const isoStr = new Date(date).toISOString();
   const formattedDate = isoStr.split('T')[0];
   const withTimezone = (options && options.timezone) && typeof options.timezone.enabled === 'boolean' ? options.timezone.enabled : true;
   if (!withTimezone) {
@@ -903,14 +902,12 @@ function toXmlDate(date, options) {
 }
 
 function toXmlTime(date) {
-  date = new Date(date);
-  const isoStr = date.toISOString();
+  const isoStr = new Date(date).toISOString();
   return isoStr.split('T')[1];
 }
 
 function toXmlDateTime(date) {
-  date = new Date(date);
-  return date.toISOString();
+  return new Date(date).toISOString();
 }
 
 /**

--- a/test/xs-date-format-test.js
+++ b/test/xs-date-format-test.js
@@ -57,10 +57,8 @@ describe('xs-date-format-tests', function() {
 
     it('converts date to xml date without Z', function() {
       var xmlDate = xmlHandler.toXmlDate(inputDate, {
-        date: {
-          timezone: {
-            enabled: false,
-          },
+        timezone: {
+          enabled: false,
         },
       });
       assert.equal(xmlDate, '2019-03-27');
@@ -83,10 +81,8 @@ describe('xs-date-format-tests', function() {
 
     it('converts string to xml date without Z', function() {
       var xmlDate = xmlHandler.toXmlDate(inputDateStr, {
-        date: {
-          timezone: {
-            enabled: false,
-          },
+        timezone: {
+          enabled: false,
         },
       });
       assert.equal(xmlDate, '2019-03-27');

--- a/test/xs-date-format-test.js
+++ b/test/xs-date-format-test.js
@@ -55,6 +55,17 @@ describe('xs-date-format-tests', function() {
       assert.equal(xmlDate, '2019-03-27Z');
     });
 
+    it('converts date to xml date without Z', function() {
+      var xmlDate = xmlHandler.toXmlDate(inputDate, {
+        date: {
+          timezone: {
+            enabled: false,
+          },
+        },
+      });
+      assert.equal(xmlDate, '2019-03-27');
+    });
+
     it('converts date to xml time', function () {
       var xmlTime = xmlHandler.toXmlTime(inputDate);
       assert.equal(xmlTime, '04:01:01.000Z');
@@ -69,6 +80,18 @@ describe('xs-date-format-tests', function() {
       var xmlDate = xmlHandler.toXmlDate(inputDateStr);
       assert.equal(xmlDate, '2019-03-27Z');
     });
+
+    it('converts string to xml date without Z', function() {
+      var xmlDate = xmlHandler.toXmlDate(inputDateStr, {
+        date: {
+          timezone: {
+            enabled: false,
+          },
+        },
+      });
+      assert.equal(xmlDate, '2019-03-27');
+    });
+
 
     it('converts string to xml time', function () {
       var xmlTime = xmlHandler.toXmlTime(inputDateStr);


### PR DESCRIPTION
### Description
The current version of the library always puts the timezone symbol **Z** at every end of date despite that not all soap services support this date format.

I've extended the `options` parameter for passing the optional `date.timezone` parameter to `XmlHandler` and nested functions for using the optional timezone symbol.

The next code is an example of disabling timezones in the date's string:
```js
const handler = new XMLHandler({}, {
  date: {
    timezone: {
      enabled: false,   
  },
});
```

By default `enabled` value is `true` for avoiding breaking changes for the existing API.

#### Related issues
- connect to  #289

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
