### PR TITLE
fix: ref in attributeGroup not working

### DIFF
--- a/src/parser/xsd/attributeGroup.js
+++ b/src/parser/xsd/attributeGroup.js
@@ -19,6 +19,9 @@ class AttributeGroup extends XSDElement {
   }
 
   describe(definitions) {
+    if (!this.ref && this.$ref) {
+      this.resolve(definitions.schemas);
+    }
     if (this.descriptor) return this.descriptor;
     if (this.ref) {
       this.descriptor = this.ref.describe(definitions);

--- a/test/wsdl-attributegroup-refs-test.js
+++ b/test/wsdl-attributegroup-refs-test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var fs = require('fs'),
+    soap = require('..').soap,
+    http = require('http'),
+    WSDL = soap.WSDL,
+    assert = require('assert'),
+    QName = require('..').QName;
+
+describe('wsdl-attributegroup-refs-test', function() {
+
+  var server = null;
+  var hostname = '127.0.0.1';
+  var port = 0;
+
+  before(function(done) {
+    server = http.createServer(function (req, res) {
+      res.statusCode = 200;
+      res.write(JSON.stringify({tempResponse: 'temp'}), 'utf8');
+      res.end();
+    }).listen(port, hostname, done);
+  });
+
+  after(function(done) {
+    server.close();
+    server = null;
+    done();
+  });
+
+  it('should prefix namespaced attributes from an attributeGroup ref', function (done) {
+    soap.createClient(__dirname + '/wsdl/attributegroup_ref.wsdl', function (err, client) {
+      assert.ok(client);
+      var data = {
+          DummyRequest: {
+              Id: 1,
+              Option: { $attributes: { toBeNamespaced: '0', notNamespaced: '1' } },
+          }
+      };
+      /* In the previous implementation the result was:
+        ...<Option toBeNamespaced="0" notNamespaced="1"/>
+        Because attribute definitions were missing from the request descriptor. Updated to generate below:
+        ...<Option xmlns:ns2="http://www.dummy.example.org/dummy.xsd" ns2:toBeNamespaced="0" notNamespaced="1"/>
+      */
+      client['MyService']['MyServicePort']['GetDummy'](data, function(err, result) {
+        assert.ok(client.lastRequest);
+        assert.ok(client.lastMessage);
+        assert.ok(client.lastEndpoint);
+        assert.ok(client.lastMessage.includes(':toBeNamespaced="0"'));
+        assert.ok(client.lastMessage.includes(' notNamespaced="1"'));
+        done();
+        return;
+      });
+    }, 'http://' + hostname + ':' + server.address().port);
+  });
+
+});

--- a/test/wsdl/attributegroup_ref.wsdl
+++ b/test/wsdl/attributegroup_ref.wsdl
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<wsdl:definitions name="MyService"
+    targetNamespace="http://www.dummy.example.org/dummy.wsdl"
+          xmlns:tns="http://www.dummy.example.org/dummy.wsdl"
+          xmlns:xsd1="http://www.dummy.example.org/dummy.xsd"
+          xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+          xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+          xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <wsdl:types>
+    <xsd:schema targetNamespace="http://www.dummy.example.org/dummy.xsd"
+                 xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+      <xsd:element name="DummyRequest" type="xsd1:DummyRequestType"/>
+      <xsd:element name="DummyResponse" type="xsd1:DummyResponseType"/>
+
+      <xsd:complexType name="DummyRequestType">
+        <xsd:sequence>
+          <xsd:element ref="xsd1:Id"    minOccurs="0" maxOccurs="1"/>
+          <xsd:element name="Option" type="xsd1:DummyOptionType" minOccurs="1" maxOccurs="1"/>
+        </xsd:sequence>
+      </xsd:complexType>
+
+      <xsd:complexType name="DummyResponseType">
+      </xsd:complexType>
+
+      <xsd:complexType name="DummyOptionType">
+        <xsd:sequence>
+        </xsd:sequence>
+        <xsd:attributeGroup ref="xsd1:DummyRequestOptionAttribGroup"/>
+      </xsd:complexType>
+
+      <xsd:element name="Id"          type="xsd:string"/>
+
+      <xsd:attributeGroup name="DummyRequestOptionAttribGroup">
+        <xsd:attribute ref ="xsd1:toBeNamespaced" use="required"/>
+      </xsd:attributeGroup>
+
+      <xsd:attribute name="toBeNamespaced"   type="xsd:integer"/>
+
+    </xsd:schema>
+  </wsdl:types>
+
+  <wsdl:message name="DummyRequestMsg">
+    <wsdl:part name="body" element="xsd1:DummyRequest"/>
+  </wsdl:message>
+  <wsdl:message name="DummyResponseMsg">
+    <wsdl:part name="body" element="xsd1:DummyResponse"/>
+  </wsdl:message>
+
+  <wsdl:portType name ="MyServicePortType">
+    <wsdl:operation name ="GetDummy">
+      <wsdl:input message="tns:DummyRequestMsg" name="GetDummyRequest"/>
+      <wsdl:output message="tns:DummyResponseMsg" name="GetDummyResponse"/>
+    </wsdl:operation>
+  </wsdl:portType>
+
+  <wsdl:binding name="MyServiceBinding" type="tns:MyServicePortType">
+
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+
+    <wsdl:operation name="GetDummy">
+      <soap:operation soapAction="GetDummy"/>
+      <wsdl:input name="GetDummyRequest">
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output name="GetDummyResponse">
+        <soap:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+
+  </wsdl:binding>
+
+  <wsdl:service name="MyService">
+    <wsdl:port name="MyServicePort" binding="tns:MyServiceBinding">
+      <soap:address location="http://www.example.com/v1"/>
+    </wsdl:port>
+  </wsdl:service>
+
+</wsdl:definitions>


### PR DESCRIPTION
### Description

Fixed issue in `src/parser/xsd/attributeGroup.js` where the $ref wasn't resolved.

Added test to verify the behaviour with a sample request.

#### Related issues

- connect to #526

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
