### PR TITLE
chore: drop support for Node.js 12 and lower

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [10, 12, 14, 16]
+        node-version: [14, 16, 18]
         include:
           - os: macos-latest
-            node-version: 14 # LTS
+            node-version: 18 # LTS
           - os: windows-latest
-            node-version: 14 # LTS
+            node-version: 18 # LTS
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "strong-soap",
-      "version": "3.4.2",
+      "version": "3.4.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -51,7 +51,7 @@
         "timekeeper": "^2.2.0"
       },
       "engines": {
-        "node": ">=8.11.1"
+        "node": ">=14"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.4.3",
   "description": "A minimal node SOAP client",
   "engines": {
-    "node": ">=8.11.1"
+    "node": ">=14"
   },
   "dependencies": {
     "compress": "^0.99.0",


### PR DESCRIPTION
### Description

BREAKING CHANGE: Drop support for Node.js 12 and lower.


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
