### PR TITLE
fix: update xmlHandler.js - try..catch cast to Date

### DIFF
--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -892,22 +892,34 @@ function parseValue(text, descriptor) {
  * @returns 
  */
 function toXmlDate(date, options) {
-  const isoStr = new Date(date).toISOString();
-  const formattedDate = isoStr.split('T')[0];
-  const withTimezone = (options && options.timezone) && typeof options.timezone.enabled === 'boolean' ? options.timezone.enabled : true;
-  if (!withTimezone) {
-    return formattedDate;
+  try {
+    const isoStr = new Date(date).toISOString();
+    const formattedDate = isoStr.split('T')[0];
+    const withTimezone = (options && options.timezone) && typeof options.timezone.enabled === 'boolean' ? options.timezone.enabled : true;
+    if (!withTimezone) {
+      return formattedDate;
+    }
+    return formattedDate + 'Z';  
+  } catch (err) {
+    return date;
   }
-  return formattedDate + 'Z';
 }
 
 function toXmlTime(date) {
-  const isoStr = new Date(date).toISOString();
-  return isoStr.split('T')[1];
+  try {
+    const isoStr = new Date(date).toISOString();
+    return isoStr.split('T')[1];  
+  } catch (err) {
+    return date;
+  }
 }
 
 function toXmlDateTime(date) {
-  return new Date(date).toISOString();
+  try {
+    return new Date(date).toISOString();  
+  } catch (err) {
+    return date; 
+  }
 }
 
 /**

--- a/test/xs-date-format-test.js
+++ b/test/xs-date-format-test.js
@@ -98,6 +98,11 @@ describe('xs-date-format-tests', function() {
       var xmlDateTime = xmlHandler.toXmlDateTime(inputDateStr);
       assert.equal(xmlDateTime, '2019-03-27T04:01:01.000Z');
     });
+    
+    it('returns invalid date string as is', function () {
+      var xmlDateTime = xmlHandler.toXmlDateTime('23091990');
+      assert.equal(xmlDateTime, '23091990');
+    });
   });
   
 });


### PR DESCRIPTION
### Description

Some SOAP services (like the one we're working with) may have a date descriptor but they expect a date in the wrong format, like "23091990"
In this case, the XMLHandler throws an error, but it would be better to just pass the value as is. Adding a try..catch block solves this problem.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
