### PR TITLE
chore: drop Node.js 16 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.5.6",
   "description": "A minimal node SOAP client",
   "engines": {
-    "node": "16 || 18 || 20 || 21"
+    "node": "18 || 20 || 21"
   },
   "dependencies": {
     "compress": "^0.99.0",


### PR DESCRIPTION
### Description

According to Node.js LTS schedule, Node.js 16 has reached EOL. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
