### PR TITLE
chore: added new parameter "textTrim" in XMLHandler

### DIFF
--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -32,6 +32,7 @@ class XMLHandler {
    * @param {Object} [options.date]
    * @param {Object} [options.date.timezone]
    * @param {boolean} [options.date.timezone.enabled]
+     @param {boolean} [options.trimText]
    */
   constructor(schemas, options) {
     this.schemas = schemas || {};
@@ -709,7 +710,9 @@ class XMLHandler {
     };
 
     p.ontext = function(text) {
-      text = text && text.trim();
+      if (self.options.trimText) {
+        text = text && text.trim();
+      }
       if (!text.length)
         return;
 

--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -44,6 +44,7 @@ class XMLHandler {
     this.options.date = this.options.date || {};
     this.options.date.timezone = this.options.date.timezone || {};
     this.options.date.timezone.enabled = typeof this.options.date.timezone.enabled === 'boolean' ? this.options.date.timezone.enabled : true;
+    this.options.trimText = typeof this.options.trimText === 'boolean' ? this.options.trimText : true;
   }
 
   jsonToXml(node, nsContext, descriptor, val) {


### PR DESCRIPTION
### Description
Added new boolean parameter "textTrim" to options object in XMLHandler constructor. This new parameter is used in p.ontext method. The default value is true for backward compatibility.

Refers to issue #610