### PR TITLE
chore: added new parameter to control the xml parsing

### DIFF
--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -32,6 +32,7 @@ class XMLHandler {
    * @param {Object} [options.date]
    * @param {Object} [options.date.timezone]
    * @param {boolean} [options.date.timezone.enabled]
+     @param {boolean} [options.trimText]
    */
   constructor(schemas, options) {
     this.schemas = schemas || {};
@@ -709,7 +710,9 @@ class XMLHandler {
     };
 
     p.ontext = function(text) {
-      text = text && text.trim();
+      if (self.options.trimText) {
+        text = text && text.trim();
+      }
       if (!text.length)
         return;
 

--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -32,7 +32,7 @@ class XMLHandler {
    * @param {Object} [options.date]
    * @param {Object} [options.date.timezone]
    * @param {boolean} [options.date.timezone.enabled]
-     @param {boolean} [options.trimText]
+   * @param {boolean} [options.trimText]
    */
   constructor(schemas, options) {
     this.schemas = schemas || {};

--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -44,6 +44,7 @@ class XMLHandler {
     this.options.date = this.options.date || {};
     this.options.date.timezone = this.options.date.timezone || {};
     this.options.date.timezone.enabled = typeof this.options.date.timezone.enabled === 'boolean' ? this.options.date.timezone.enabled : true;
+    this.options.trimText = typeof this.options.trimText === 'boolean' ? this.options.trimText : true;
   }
 
   jsonToXml(node, nsContext, descriptor, val) {


### PR DESCRIPTION
### Description
New parameter "trimText" in XMLHandler constructor, which is used in p.ontext method to allow or prevent trimming the text value.

#### Related issues
#610

