### PR TITLE
fix: handling attributes on the body tag in the server for both rpc and document styles

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -198,7 +198,8 @@ class Server extends Base {
 
     try {
       if (binding.style === 'rpc') {
-        operationName = Object.keys(body)[0];
+        operationName = (Object.keys(body)[0] === (self.wsdl.options.attributesKey || 'attributes') ?
+        Object.keys(body)[1] : Object.keys(body)[0]);
 
         self.emit('request', obj, operationName);
         if (headers)
@@ -214,8 +215,8 @@ class Server extends Base {
           style: 'rpc'
         }, req, callback);
       } else { //document style
-        var messageElemName = (Object.keys(body)[0] === 'attributes' ?
-          Object.keys(body)[1] : Object.keys(body)[0]);
+        var messageElemName = (Object.keys(body)[0] === (self.wsdl.options.attributesKey || 'attributes') ?
+        Object.keys(body)[1] : Object.keys(body)[0]);
         var pair = binding.topElements[messageElemName];
 
         var operationName, outputName;


### PR DESCRIPTION
### Description

When adding attributes to the body tag (e.g. ` <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">`), the library currently returns the following error:

> TypeError: Cannot read properties of undefined (reading 'output')
    at Server._executeMethod (/usr/src/app/node_modules/strong-soap/src/server.js:337:44)
    at Server._process (/usr/src/app/node_modules/strong-soap/src/server.js:207:14)
    at IncomingMessage.<anonymous> (/usr/src/app/node_modules/strong-soap/src/server.js:112:18)
    at IncomingMessage.emit (node:events:513:28)
    at endReadableNT (node:internal/streams/readable:1359:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)

Currently, this was only supported using the document style and when the attributes key was set to the default "attributes". This update adds support for rpc style as well and updates the document style to get the key from the server options.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #815

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

Obs. I could not find a way to send an attribute on the body tag from the client or any test that covered the same scenario for the existing supported case (document style and attributesKey set to default "attributes"), so that's why no new unit tests were added.

- [x] New tests added or existing tests modified to cover all changes
- [X] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
