### PR TITLE
Develop

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+2024-11-11, Version 4.1.6
+=========================
+
+Placeholder for package maintainer
+
+ * feat: Override default strong-soap behaviour when mapping undefined element values to self closing tags (<tag/> instead of <tag xsi:nil=true></tag>. Option is ignoreAttributesUndefined, to enable option set to false. (Jamie Nicholson)
+
 2024-10-10, Version 4.1.5
 =========================
 

--- a/README.md
+++ b/README.md
@@ -530,6 +530,10 @@ soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', wsdlOptions, funct
 
 To see it in practice, consider the sample in: [test/request-response-samples/addPets__force_namespaces](https://github.com/loopbackio/strong-soap/tree/master/test/request-response-samples/addPets__force_namespaces)
 
+### Mapping of undefined element values
+
+When the wsdl attribute nillable="true" it set, JSON values will map to null and XML values map to nillable='true' unless ignoreAttributesUndefined is set to false. When ignoreAttributesUndefined is set to false undefined element values will map to a self closing tag i.e. <tag/>
+
 ## XMLHandler
 
 XMLHandler enables you to to convert a JSON object to XML and XML to a JSON object.  It can also parse an XML string or stream into the XMLBuilder tree.

--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -32,6 +32,7 @@ class XMLHandler {
    * @param {Object} [options.date]
    * @param {Object} [options.date.timezone]
    * @param {boolean} [options.date.timezone.enabled]
+   * @param {boolean} [option.ignoreAttributesUndefined]
    */
   constructor(schemas, options) {
     this.schemas = schemas || {};
@@ -43,6 +44,7 @@ class XMLHandler {
     this.options.date = this.options.date || {};
     this.options.date.timezone = this.options.date.timezone || {};
     this.options.date.timezone.enabled = typeof this.options.date.timezone.enabled === 'boolean' ? this.options.date.timezone.enabled : true;
+    this.options.ignoreAttributesUndefined = typeof this.options.ignoreAttributesUndefined === 'boolean' ? this.options.ignoreAttributesUndefined : true;
   }
 
   jsonToXml(node, nsContext, descriptor, val) {
@@ -162,8 +164,8 @@ class XMLHandler {
         }
       }
 
-      if (val == null) {
-        if (descriptor.isNillable) {
+      if (val === null ||(val === undefined && this.options.ignoreAttributesUndefined == true)) {
+        if (descriptor.isNillable ) {
           // Set xsi:nil = true
           declareNamespace(nsContext, element, 'xsi', helper.namespaces.xsi);
           if (typeof element.attribute === 'function') {

--- a/test/nillable-test.js
+++ b/test/nillable-test.js
@@ -52,7 +52,6 @@ describe('Nillable tests ', function() {
 
         client.addPets(requestArgs, function (err, result, body) {
           var request = client.lastMessage;
-          console.log(client.lastMessage)
           //check if the Breed element has xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" atttribute
           var index = request.indexOf('<Breed xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>');
           assert.ok(index > -1);
@@ -86,7 +85,6 @@ describe('Nillable tests ', function() {
         };
 
         client.addPets(requestArgs, function (err, result, body) {
-          console.log(client.lastMessage)
           var request = client.lastMessage;
           //check if the pet element has xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" atttribute
           var index = request.indexOf('<pet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>');

--- a/test/undefined-test.js
+++ b/test/undefined-test.js
@@ -8,12 +8,11 @@
 var soap = require('..').soap,
     assert = require('assert');
 
-describe('Nillable tests ', function() {
+describe('Undefined tests', function() {
 
   /*
-   In case of nillable="true" defined on 'breed' simpleType in the WSDL. If value of 'breed' is null,
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" is added to indicate the value
-   is null for this element.
+  If value of 'breed' (simpleType in the WSDL) is undefined,
+  and options.ignoreAttributesUndefined is true, the element will be empty.
 
    Request
    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -23,7 +22,7 @@ describe('Nillable tests ', function() {
        <ns1:addPets xmlns:ns1="http://tempuri.org/">
          <pet>
            <Name>max</Name>
-           <Breed xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+           <Breed/>
          </pet>
          <pet>
            <Name>sunny</Name>
@@ -34,14 +33,16 @@ describe('Nillable tests ', function() {
    </soap:Envelope>
    */
 
-    it("nillable='true' defined for simpleType", function (done) {
-      soap.createClient(__dirname + '/wsdl/strict/nillable.wsdl', function (err, client) {
+    it("undefined and options.ignoreAttributesUndefined false for simpleType", function (done) {
+      soap.createClient(__dirname + '/wsdl/strict/nillable.wsdl',{
+        "ignoreAttributesUndefined":false
+      }, function (err, client) {
         assert.ok(!err);
         var requestArgs = {
          "pet": [
            {
             "Name"  : "max",
-            "Breed" : null
+            "Breed" : undefined
            },
            {
             "Name": "sunny",
@@ -52,9 +53,8 @@ describe('Nillable tests ', function() {
 
         client.addPets(requestArgs, function (err, result, body) {
           var request = client.lastMessage;
-          console.log(client.lastMessage)
-          //check if the Breed element has xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" atttribute
-          var index = request.indexOf('<Breed xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>');
+          //check if the Breed element is empty
+          var index = request.indexOf('<Breed/>');
           assert.ok(index > -1);
           done();
         });
@@ -62,9 +62,8 @@ describe('Nillable tests ', function() {
     });
 
     /*
-    In case of nillable="true" defined on 'pet' complexType in the WSDL. If value of 'pet' is null,
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" is added to indicate the value
-    is null for this element.
+    In case of nillable="true" defined on 'pet' complexType in the WSDL. If value of 'pet' is undefined,
+    and options.ignoreAttributesUndefined is true the element will be empty.
 
      Request
      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -72,24 +71,25 @@ describe('Nillable tests ', function() {
         <soap:Header/>
         <soap:Body>
             <ns1:addPets xmlns:ns1="http://tempuri.org/">
-                <pet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                <pet/>
             </ns1:addPets>
         </soap:Body>
      </soap:Envelope>
      */
 
-    it("nillable='true' defined for complexType", function (done) {
-      soap.createClient(__dirname + '/wsdl/strict/nillable.wsdl', function (err, client) {
+    it("undefined and options.ignoreAttributesUndefined false for complexType", function (done) {
+      soap.createClient(__dirname + '/wsdl/strict/nillable.wsdl',{
+        "ignoreAttributesUndefined":false
+      }, function (err, client) {
         assert.ok(!err);
         var requestArgs = {
-            "pet": null
+            "pet": undefined
         };
 
         client.addPets(requestArgs, function (err, result, body) {
-          console.log(client.lastMessage)
           var request = client.lastMessage;
           //check if the pet element has xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true" atttribute
-          var index = request.indexOf('<pet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>');
+          var index = request.indexOf('<pet/>');
           assert.ok(index > -1);
           done();
         });
@@ -97,5 +97,3 @@ describe('Nillable tests ', function() {
     });
 
 });
-
-


### PR DESCRIPTION
### Description

Added feature, new wsdl option ignoreAttributesUndefined, when set to false undefined attribute values will be mapped to xml self closing tags i.e. </tag> with no values. Only nulls will set XML attribute value to xsi:nil="true" when nillable="true" is defined in the wsdl.

#### Related issues

None.

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
