### PR TITLE
chore: drop Node.js 18 support

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [18, 20, 22, 23]
+        node-version: [20, 22, 24]
         include:
           - os: macos-latest
             node-version: 22 # LTS

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.1.14",
   "description": "A minimal node SOAP client",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "dependencies": {
     "@cypress/request": "^3.0.8",
@@ -67,5 +67,5 @@
     "should": "^13.2.3",
     "timekeeper": "^2.3.1"
   },
-  "author": "IBM Corp."
+  "author": "IBM Corp. and LoopBack contributors"
 }


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js 18 support

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
