### PR TITLE
fix: revert debug@4.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "strong-soap",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@cypress/request": "^3.0.9",
         "compress": "^0.99.0",
-        "debug": "^4.4.2",
+        "debug": "^4.4.1",
         "httpntlm": "^1.8.13",
         "lodash": "^4.17.21",
         "node-rsa": "^1.1.1",
@@ -3793,9 +3793,9 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.2.tgz",
-      "integrity": "sha512-IQeXCZhGRpFiLI3MYlCGLjNssUBiE8G21RMyNH35KFsxIvhrMeh5jXuG82woDZrYX9pgqHs+GF5js2Ducn4y4A==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@cypress/request": "^3.0.9",
     "compress": "^0.99.0",
-    "debug": "^4.4.2",
+    "debug": "^4.4.1",
     "httpntlm": "^1.8.13",
     "lodash": "^4.17.21",
     "node-rsa": "^1.1.1",


### PR DESCRIPTION
### Description
Revert to debug@4.4.1. 

Background info: https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
