### PR TITLE
fix: check body property when is undefined

### DIFF
--- a/src/parser/wsdl/operation.js
+++ b/src/parser/wsdl/operation.js
@@ -293,7 +293,7 @@ class Operation extends WSDLElement {
         </soap:Fault>
      </soap:Body>
      */
-    if (isOutput && parameterDescriptor && parameterDescriptor.body.Fault) {
+    if (isOutput && parameterDescriptor && parameterDescriptor.body && parameterDescriptor.body.Fault) {
       let xsdStr = new QName(helper.namespaces.xsd, 'string', 'xsd');
       var form;
       if (soapVersion === '1.1') {


### PR DESCRIPTION
### Description

When using client.describe(), the "if" condition crashes when trying to read the Fault property of the body object which could be undefined in some scenarios.

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
