### PR TITLE
BREAKING CHANGE: drop Node.js 20 support

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: [20, 22, 24]
+        node-version: [22, 24, 26]
         include:
           - os: macos-latest
             node-version: 22 # LTS
@@ -68,10 +68,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 20.20.2
+          node-version: 22
       - name: Bootstrap project
         run: npm ci --ignore-scripts
       - name: Verify commit linting

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "5.0.10",
   "description": "A minimal node SOAP client",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "dependencies": {
     "@cypress/request": "^3.0.10",


### PR DESCRIPTION
BREAKING CHANGE: Drop Node.js 20 support

### Description

Node.js 20 has reached EOL. https://nodejs.org/en/about/previous-releases

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
