### PR TITLE
fix: run coverall on ubuntu only

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -42,6 +42,7 @@ jobs:
       - name: Run tests
         run: npm test --ignore-scripts
       - name: Coveralls Parallel
+        if: matrix.os == 'ubuntu-latest'
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
### Description
Got the error: 
```
Run echo "Warning: The coverage-reporter-platform parameter is not available on macOS. The default version for macOS will be used." >&2
```

Since coverall is run on other OS, we can skip the one on macOS. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
