### PR TITLE
fix: default SOAP Fault responses to HTTP 500

### DIFF
--- a/README.md
+++ b/README.md
@@ -736,6 +736,21 @@ An example of using the SOAP server is in [test/server-test](https://github.com/
 A service method can reply with a SOAP Fault to a client by `throw`ing an
 object with a `Fault` property.
 
+Fault responses default to HTTP status code `500`, in line with the SOAP
+specification. To return a different status code, set a `statusCode` property on
+the `Fault` object; that value is used as the HTTP status code and is not
+serialized into the Fault XML. For example:
+
+```js
+    throw {
+      Fault: {
+        statusCode: 401,
+        faultcode: "soap:Client",
+        faultstring: "Unauthorized"
+      }
+    }
+```
+
 Example SOAP 1.1 Fault:
 
 ```js

--- a/src/server.js
+++ b/src/server.js
@@ -391,6 +391,10 @@ class Server extends Base {
     if (error.Fault.statusCode) {
       statusCode = error.Fault.statusCode;
       error.Fault.statusCode = undefined;
+    } else {
+      // Default SOAP Fault responses to HTTP 500 per the SOAP spec. A service
+      // method can override this by setting a `statusCode` on the Fault object.
+      statusCode = 500;
     }
 
     var operationDescriptor = operation.describe(this.wsdl.definitions);

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -421,7 +421,7 @@ describe('SOAP Server', function() {
         assert.equal(fault.Code.Value, "soap:Sender");
         assert.equal(fault.Reason.Text, "Processing Error");
         assert.equal(body.toString(), expectedBody);
-        assert.equal(err.response.statusCode, 200);
+        assert.equal(err.response.statusCode, 500);
         done();
       });
     });
@@ -443,6 +443,7 @@ describe('SOAP Server', function() {
           "Body should contain faultcode-element without namespace");
         assert.ok(body.match(/<faultstring>.*<\/faultstring>/g),
           "Body should contain faultstring-element without namespace");
+        assert.equal(err.response.statusCode, 500);
         done();
       });
     });


### PR DESCRIPTION
### Description

When a service method replies with a SOAP Fault, the server serialized the fault body but returned it with **HTTP status code 200**. This change defaults Fault responses to **HTTP 500** when the `Fault` object does not specify an explicit `statusCode`.

- `src/server.js` (`_sendError`): when `error.Fault.statusCode` is not set, default `statusCode` to `500`. An explicit `Fault.statusCode` still takes precedence and is stripped from the object so it is not serialized into the Fault XML (unchanged behavior).
- `test/server-test.js`: the SOAP 1.2 fault test now asserts `err.response.statusCode === 500` (was `200`), and the SOAP 1.1 fault test adds the same assertion to lock in the default for the 1.1 path.
- `README.md` (SOAP Fault section): documents that faults default to HTTP 500 and that a custom code can be set via a `statusCode` property on the `Fault` object.

Why this matters: returning HTTP 200 for a SOAP Fault breaks HTTP-level error handling: clients, load balancers, and proxies that key off the status code treat a faulted call as successful. The SOAP specification expects a fault to be returned with a 5xx status. As reported in #346, the only workaround today is to set `statusCode: 500` on every thrown Fault; this makes 500 the default while preserving the override for callers that need a different code (e.g. 401) or the previous 200 behavior.

Note: SOAP 1.2 technically maps a `Sender` fault to 400 and a `Receiver` fault to 500. Deriving the code from `Fault.Code.Value` would be more spec-pure but larger in scope; the issue asks specifically for 500 as the default, so this keeps the change bounded and overridable. That derivation could be a follow-up.

Verified with `npm test`: the updated SOAP 1.1/1.2 fault tests assert statusCode 500 and pass; the full suite is green apart from one pre-existing flaky test that also fails on a clean `master`.

#### Related issues

- connect to #346

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](http://loopback.io/doc/en/contrib/style-guide.html)

Closes #346
